### PR TITLE
Removed unused String.format() method call

### DIFF
--- a/src/main/java/com/sumologic/http/sender/SumoHttpSender.java
+++ b/src/main/java/com/sumologic/http/sender/SumoHttpSender.java
@@ -46,166 +46,166 @@ import java.util.regex.Pattern;
 
 
 public class SumoHttpSender {
-	private static final Logger logger = LogManager.getRootLogger();
+    private static final Logger logger = LogManager.getRootLogger();
 
-	private static final String SUMO_SOURCE_NAME_HEADER = "X-Sumo-Name";
-	private static final String SUMO_SOURCE_CATEGORY_HEADER = "X-Sumo-Category";
-	private static final String SUMO_SOURCE_HOST_HEADER = "X-Sumo-Host";
-	private static final String SUMO_CLIENT_HEADER = "X-Sumo-Client";
+    private static final String SUMO_SOURCE_NAME_HEADER = "X-Sumo-Name";
+    private static final String SUMO_SOURCE_CATEGORY_HEADER = "X-Sumo-Category";
+    private static final String SUMO_SOURCE_HOST_HEADER = "X-Sumo-Host";
+    private static final String SUMO_CLIENT_HEADER = "X-Sumo-Client";
 
-	private long retryIntervalMs = 10000L;
-	private int connectionTimeoutMs = 1000;
-	private int socketTimeoutMs = 60000;
-	private String url = null;
-	private String sourceName = null;
-	private String sourceCategory = null;
-	private String sourceHost = null;
-	private ProxySettings proxySettings = null;
-	private CloseableHttpClient httpClient = null;
-	private String clientHeaderValue = null;
-	private String retryableHttpCodeRegex = "^5.*";
-	private Pattern retryableHttpCodeRegexPattern = null;
+    private long retryIntervalMs = 10000L;
+    private int connectionTimeoutMs = 1000;
+    private int socketTimeoutMs = 60000;
+    private String url = null;
+    private String sourceName = null;
+    private String sourceCategory = null;
+    private String sourceHost = null;
+    private ProxySettings proxySettings = null;
+    private CloseableHttpClient httpClient = null;
+    private String clientHeaderValue = null;
+    private String retryableHttpCodeRegex = "^5.*";
+    private Pattern retryableHttpCodeRegexPattern = null;
 
-	public ProxySettings getProxySettings() {
-		return proxySettings;
-	}
+    public ProxySettings getProxySettings() {
+        return proxySettings;
+    }
 
-	public void setProxySettings(ProxySettings proxySettings) {
-		this.proxySettings = proxySettings;
-	}
+    public void setProxySettings(ProxySettings proxySettings) {
+        this.proxySettings = proxySettings;
+    }
 
-	public void setRetryIntervalMs(long retryIntervalMs) {
-		this.retryIntervalMs = retryIntervalMs;
-	}
+    public void setRetryIntervalMs(long retryIntervalMs) {
+        this.retryIntervalMs = retryIntervalMs;
+    }
 
-	public void setUrl(String url) {
-		this.url = url;
-	}
+    public void setUrl(String url) {
+        this.url = url;
+    }
 
-	public void setSourceName(String sourceName) {
-		this.sourceName = sourceName;
-	}
+    public void setSourceName(String sourceName) {
+        this.sourceName = sourceName;
+    }
 
-	public void setSourceCategory(String sourceCategory) {
-		this.sourceCategory = sourceCategory;
-	}
+    public void setSourceCategory(String sourceCategory) {
+        this.sourceCategory = sourceCategory;
+    }
 
-	public void setSourceHost(String sourceHost) {
-		this.sourceHost = sourceHost;
-	}
+    public void setSourceHost(String sourceHost) {
+        this.sourceHost = sourceHost;
+    }
 
-	public void setConnectionTimeoutMs(int connectionTimeoutMs) {
-		this.connectionTimeoutMs = connectionTimeoutMs;
-	}
+    public void setConnectionTimeoutMs(int connectionTimeoutMs) {
+        this.connectionTimeoutMs = connectionTimeoutMs;
+    }
 
-	public void setSocketTimeoutMs(int socketTimeoutMs) {
-		this.socketTimeoutMs = socketTimeoutMs;
-	}
+    public void setSocketTimeoutMs(int socketTimeoutMs) {
+        this.socketTimeoutMs = socketTimeoutMs;
+    }
 
-	public void setClientHeaderValue(String clientHeaderValue) {
-		this.clientHeaderValue = clientHeaderValue;
-	}
+    public void setClientHeaderValue(String clientHeaderValue) {
+        this.clientHeaderValue = clientHeaderValue;
+    }
 
-	public void setRetryableHttpCodeRegex(String retryableHttpCodeRegex) {
-		this.retryableHttpCodeRegex = retryableHttpCodeRegex;
-	}
+    public void setRetryableHttpCodeRegex(String retryableHttpCodeRegex) {
+        this.retryableHttpCodeRegex = retryableHttpCodeRegex;
+    }
 
-	public boolean isInitialized() {
-		return httpClient != null;
-	}
+    public boolean isInitialized() {
+        return httpClient != null;
+    }
 
-	public void init() {
-		RequestConfig requestConfig = RequestConfig.custom()
-				.setSocketTimeout(socketTimeoutMs)
-				.setConnectTimeout(connectionTimeoutMs)
-				.setCookieSpec(CookieSpecs.STANDARD)
-				.build();
+    public void init() {
+        RequestConfig requestConfig = RequestConfig.custom()
+                .setSocketTimeout(socketTimeoutMs)
+                .setConnectTimeout(connectionTimeoutMs)
+                .setCookieSpec(CookieSpecs.STANDARD)
+                .build();
 
-		HttpClientBuilder builder = HttpClients.custom()
-				.setConnectionManager(new PoolingHttpClientConnectionManager())
-				.setDefaultRequestConfig(requestConfig);
+        HttpClientBuilder builder = HttpClients.custom()
+                .setConnectionManager(new PoolingHttpClientConnectionManager())
+                .setDefaultRequestConfig(requestConfig);
 
-		if (proxySettings != null) {
-			HttpProxySettingsCreator creator = new HttpProxySettingsCreator(proxySettings);
-			creator.configureProxySettings(builder);
-		}
+        if (proxySettings != null) {
+            HttpProxySettingsCreator creator = new HttpProxySettingsCreator(proxySettings);
+            creator.configureProxySettings(builder);
+        }
 
-		httpClient = builder.build();
+        httpClient = builder.build();
 
-		retryableHttpCodeRegexPattern = Pattern.compile(retryableHttpCodeRegex);
-	}
+        retryableHttpCodeRegexPattern = Pattern.compile(retryableHttpCodeRegex);
+    }
 
-	public void close() throws IOException {
-		httpClient.close();
-		httpClient = null;
-	}
+    public void close() throws IOException {
+        httpClient.close();
+        httpClient = null;
+    }
 
-	public void send(String body) {
-		keepTrying(body);
-	}
+    public void send(String body) {
+        keepTrying(body);
+    }
 
-	private void keepTrying(String body) {
-		boolean success = false;
-		do {
-			try {
-				trySend(body);
-				success = true;
-			} catch (Exception e) {
-				try {
-					Thread.sleep(retryIntervalMs);
-				} catch (InterruptedException e1) {
-					break;
-				}
-			}
-		} while (!success && !Thread.currentThread().isInterrupted());
-	}
+    private void keepTrying(String body) {
+        boolean success = false;
+        do {
+            try {
+                trySend(body);
+                success = true;
+            } catch (Exception e) {
+                try {
+                    Thread.sleep(retryIntervalMs);
+                } catch (InterruptedException e1) {
+                    break;
+                }
+            }
+        } while (!success && !Thread.currentThread().isInterrupted());
+    }
 
-	private void trySend(String body) throws IOException {
-		HttpPost post = null;
-		try {
-			if (url == null)
-				throw new IOException("Unknown endpoint");
+    private void trySend(String body) throws IOException {
+        HttpPost post = null;
+        try {
+            if (url == null)
+                throw new IOException("Unknown endpoint");
 
-			post = new HttpPost(url);
-			safeSetHeader(post, SUMO_SOURCE_NAME_HEADER, sourceName);
-			safeSetHeader(post, SUMO_SOURCE_CATEGORY_HEADER, sourceCategory);
-			safeSetHeader(post, SUMO_SOURCE_HOST_HEADER, sourceHost);
-			safeSetHeader(post, SUMO_CLIENT_HEADER, clientHeaderValue);
-			post.setEntity(new StringEntity(body, Consts.UTF_8));
-			HttpResponse response = httpClient.execute(post);
-			int statusCode = response.getStatusLine().getStatusCode();
-			if (statusCode != 200) {
-				logger.warn("Received non-200 response code from Sumo Service: " + statusCode);
-				// Not success. Only retry if status matches retryableHttpCodeRegex
-				if (retryableHttpCodeRegexPattern.matcher(String.valueOf(statusCode)).find()) {
-					//need to consume the body if you want to re-use the connection.
-					EntityUtils.consume(response.getEntity());
-					throw new IOException("Encountered retryable status code: " + statusCode);
-				}
-			} else {
-				logger.debug("Successfully sent log request to Sumo Logic");
-			}
-			//need to consume the body if you want to re-use the connection.
-			EntityUtils.consume(response.getEntity());
-		} catch (ClientProtocolException e) {
-			logger.warn("Dropping message due to invalid URL: " + url);
-			try {
-				post.abort();
-			} catch (Exception ignore) { }
-			// Don't throw exception any further
-		} catch (IOException e) {
-			logger.warn("Could not send log to Sumo Logic. Reason: " + e.getMessage());
-			logger.debug(e);
-			try {
-				post.abort();
-			} catch (Exception ignore) { }
-			throw e;
-		}
-	}
+            post = new HttpPost(url);
+            safeSetHeader(post, SUMO_SOURCE_NAME_HEADER, sourceName);
+            safeSetHeader(post, SUMO_SOURCE_CATEGORY_HEADER, sourceCategory);
+            safeSetHeader(post, SUMO_SOURCE_HOST_HEADER, sourceHost);
+            safeSetHeader(post, SUMO_CLIENT_HEADER, clientHeaderValue);
+            post.setEntity(new StringEntity(body, Consts.UTF_8));
+            HttpResponse response = httpClient.execute(post);
+            int statusCode = response.getStatusLine().getStatusCode();
+            if (statusCode != 200) {
+                logger.warn("Received non-200 response code from Sumo Service: " + statusCode);
+                // Not success. Only retry if status matches retryableHttpCodeRegex
+                if (retryableHttpCodeRegexPattern.matcher(String.valueOf(statusCode)).find()) {
+                    //need to consume the body if you want to re-use the connection.
+                    EntityUtils.consume(response.getEntity());
+                    throw new IOException("Encountered retryable status code: " + statusCode);
+                }
+            } else {
+                logger.debug("Successfully sent log request to Sumo Logic");
+            }
+            //need to consume the body if you want to re-use the connection.
+            EntityUtils.consume(response.getEntity());
+        } catch (ClientProtocolException e) {
+            logger.warn("Dropping message due to invalid URL: " + url);
+            try {
+                post.abort();
+            } catch (Exception ignore) { }
+            // Don't throw exception any further
+        } catch (IOException e) {
+            logger.warn("Could not send log to Sumo Logic. Reason: " + e.getMessage());
+            logger.debug(e);
+            try {
+                post.abort();
+            } catch (Exception ignore) { }
+            throw e;
+        }
+    }
 
-	private void safeSetHeader(HttpPost post, String name, String value) {
-		if (value != null && !value.trim().isEmpty()) {
-			post.setHeader(name, value);
-		}
-	}
+    private void safeSetHeader(HttpPost post, String name, String value) {
+        if (value != null && !value.trim().isEmpty()) {
+            post.setHeader(name, value);
+        }
+    }
 }

--- a/src/main/java/com/sumologic/http/sender/SumoHttpSender.java
+++ b/src/main/java/com/sumologic/http/sender/SumoHttpSender.java
@@ -46,166 +46,166 @@ import java.util.regex.Pattern;
 
 
 public class SumoHttpSender {
-    private static final Logger logger = LogManager.getRootLogger();
+	private static final Logger logger = LogManager.getRootLogger();
 
-    private static final String SUMO_SOURCE_NAME_HEADER = "X-Sumo-Name";
-    private static final String SUMO_SOURCE_CATEGORY_HEADER = "X-Sumo-Category";
-    private static final String SUMO_SOURCE_HOST_HEADER = "X-Sumo-Host";
-    private static final String SUMO_CLIENT_HEADER = "X-Sumo-Client";
+	private static final String SUMO_SOURCE_NAME_HEADER = "X-Sumo-Name";
+	private static final String SUMO_SOURCE_CATEGORY_HEADER = "X-Sumo-Category";
+	private static final String SUMO_SOURCE_HOST_HEADER = "X-Sumo-Host";
+	private static final String SUMO_CLIENT_HEADER = "X-Sumo-Client";
 
-    private long retryIntervalMs = 10000L;
-    private int connectionTimeoutMs = 1000;
-    private int socketTimeoutMs = 60000;
-    private String url = null;
-    private String sourceName = null;
-    private String sourceCategory = null;
-    private String sourceHost = null;
-    private ProxySettings proxySettings = null;
-    private CloseableHttpClient httpClient = null;
-    private String clientHeaderValue = null;
-    private String retryableHttpCodeRegex = "^5.*";
-    private Pattern retryableHttpCodeRegexPattern = null;
+	private long retryIntervalMs = 10000L;
+	private int connectionTimeoutMs = 1000;
+	private int socketTimeoutMs = 60000;
+	private String url = null;
+	private String sourceName = null;
+	private String sourceCategory = null;
+	private String sourceHost = null;
+	private ProxySettings proxySettings = null;
+	private CloseableHttpClient httpClient = null;
+	private String clientHeaderValue = null;
+	private String retryableHttpCodeRegex = "^5.*";
+	private Pattern retryableHttpCodeRegexPattern = null;
 
-    public ProxySettings getProxySettings() {
-        return proxySettings;
-    }
+	public ProxySettings getProxySettings() {
+		return proxySettings;
+	}
 
-    public void setProxySettings(ProxySettings proxySettings) {
-        this.proxySettings = proxySettings;
-    }
+	public void setProxySettings(ProxySettings proxySettings) {
+		this.proxySettings = proxySettings;
+	}
 
-    public void setRetryIntervalMs(long retryIntervalMs) {
-        this.retryIntervalMs = retryIntervalMs;
-    }
+	public void setRetryIntervalMs(long retryIntervalMs) {
+		this.retryIntervalMs = retryIntervalMs;
+	}
 
-    public void setUrl(String url) {
-        this.url = url;
-    }
+	public void setUrl(String url) {
+		this.url = url;
+	}
 
-    public void setSourceName(String sourceName) {
-        this.sourceName = sourceName;
-    }
+	public void setSourceName(String sourceName) {
+		this.sourceName = sourceName;
+	}
 
-    public void setSourceCategory(String sourceCategory) {
-        this.sourceCategory = sourceCategory;
-    }
+	public void setSourceCategory(String sourceCategory) {
+		this.sourceCategory = sourceCategory;
+	}
 
-    public void setSourceHost(String sourceHost) {
-        this.sourceHost = sourceHost;
-    }
+	public void setSourceHost(String sourceHost) {
+		this.sourceHost = sourceHost;
+	}
 
-    public void setConnectionTimeoutMs(int connectionTimeoutMs) {
-        this.connectionTimeoutMs = connectionTimeoutMs;
-    }
+	public void setConnectionTimeoutMs(int connectionTimeoutMs) {
+		this.connectionTimeoutMs = connectionTimeoutMs;
+	}
 
-    public void setSocketTimeoutMs(int socketTimeoutMs) {
-        this.socketTimeoutMs = socketTimeoutMs;
-    }
+	public void setSocketTimeoutMs(int socketTimeoutMs) {
+		this.socketTimeoutMs = socketTimeoutMs;
+	}
 
-    public void setClientHeaderValue(String clientHeaderValue) {
-        this.clientHeaderValue = clientHeaderValue;
-    }
+	public void setClientHeaderValue(String clientHeaderValue) {
+		this.clientHeaderValue = clientHeaderValue;
+	}
 
-    public void setRetryableHttpCodeRegex(String retryableHttpCodeRegex) {
-        this.retryableHttpCodeRegex = retryableHttpCodeRegex;
-    }
+	public void setRetryableHttpCodeRegex(String retryableHttpCodeRegex) {
+		this.retryableHttpCodeRegex = retryableHttpCodeRegex;
+	}
 
-    public boolean isInitialized() {
-        return httpClient != null;
-    }
+	public boolean isInitialized() {
+		return httpClient != null;
+	}
 
-    public void init() {
-        RequestConfig requestConfig = RequestConfig.custom()
-                .setSocketTimeout(socketTimeoutMs)
-                .setConnectTimeout(connectionTimeoutMs)
-                .setCookieSpec(CookieSpecs.STANDARD)
-                .build();
+	public void init() {
+		RequestConfig requestConfig = RequestConfig.custom()
+				.setSocketTimeout(socketTimeoutMs)
+				.setConnectTimeout(connectionTimeoutMs)
+				.setCookieSpec(CookieSpecs.STANDARD)
+				.build();
 
-        HttpClientBuilder builder = HttpClients.custom()
-                .setConnectionManager(new PoolingHttpClientConnectionManager())
-                .setDefaultRequestConfig(requestConfig);
+		HttpClientBuilder builder = HttpClients.custom()
+				.setConnectionManager(new PoolingHttpClientConnectionManager())
+				.setDefaultRequestConfig(requestConfig);
 
-        if (proxySettings != null) {
-            HttpProxySettingsCreator creator = new HttpProxySettingsCreator(proxySettings);
-            creator.configureProxySettings(builder);
-        }
+		if (proxySettings != null) {
+			HttpProxySettingsCreator creator = new HttpProxySettingsCreator(proxySettings);
+			creator.configureProxySettings(builder);
+		}
 
-        httpClient = builder.build();
+		httpClient = builder.build();
 
-        retryableHttpCodeRegexPattern = Pattern.compile(retryableHttpCodeRegex);
-    }
+		retryableHttpCodeRegexPattern = Pattern.compile(retryableHttpCodeRegex);
+	}
 
-    public void close() throws IOException {
-        httpClient.close();
-        httpClient = null;
-    }
+	public void close() throws IOException {
+		httpClient.close();
+		httpClient = null;
+	}
 
-    public void send(String body) {
-        keepTrying(body);
-    }
+	public void send(String body) {
+		keepTrying(body);
+	}
 
-    private void keepTrying(String body) {
-        boolean success = false;
-        do {
-            try {
-                trySend(body);
-                success = true;
-            } catch (Exception e) {
-                try {
-                    Thread.sleep(retryIntervalMs);
-                } catch (InterruptedException e1) {
-                    break;
-                }
-            }
-        } while (!success && !Thread.currentThread().isInterrupted());
-    }
+	private void keepTrying(String body) {
+		boolean success = false;
+		do {
+			try {
+				trySend(body);
+				success = true;
+			} catch (Exception e) {
+				try {
+					Thread.sleep(retryIntervalMs);
+				} catch (InterruptedException e1) {
+					break;
+				}
+			}
+		} while (!success && !Thread.currentThread().isInterrupted());
+	}
 
-    private void trySend(String body) throws IOException {
-        HttpPost post = null;
-        try {
-            if (url == null)
-                throw new IOException("Unknown endpoint");
+	private void trySend(String body) throws IOException {
+		HttpPost post = null;
+		try {
+			if (url == null)
+				throw new IOException("Unknown endpoint");
 
-            post = new HttpPost(url);
-            safeSetHeader(post, SUMO_SOURCE_NAME_HEADER, sourceName);
-            safeSetHeader(post, SUMO_SOURCE_CATEGORY_HEADER, sourceCategory);
-            safeSetHeader(post, SUMO_SOURCE_HOST_HEADER, sourceHost);
-            safeSetHeader(post, SUMO_CLIENT_HEADER, clientHeaderValue);
-            post.setEntity(new StringEntity(body, Consts.UTF_8));
-            HttpResponse response = httpClient.execute(post);
-            int statusCode = response.getStatusLine().getStatusCode();
-            if (statusCode != 200) {
-                logger.warn(String.format("Received non-200 response code from Sumo Service: " + statusCode));
-                // Not success. Only retry if status matches retryableHttpCodeRegex
-                if (retryableHttpCodeRegexPattern.matcher(String.valueOf(statusCode)).find()) {
-                    //need to consume the body if you want to re-use the connection.
-                    EntityUtils.consume(response.getEntity());
-                    throw new IOException("Encountered retryable status code: " + statusCode);
-                }
-            } else {
-                logger.debug("Successfully sent log request to Sumo Logic");
-            }
-            //need to consume the body if you want to re-use the connection.
-            EntityUtils.consume(response.getEntity());
-        } catch (ClientProtocolException e) {
-            logger.warn("Dropping message due to invalid URL: " + url);
-            try {
-                post.abort();
-            } catch (Exception ignore) { }
-            // Don't throw exception any further
-        } catch (IOException e) {
-            logger.warn("Could not send log to Sumo Logic. Reason: " + e.getMessage());
-            logger.debug(e);
-            try {
-                post.abort();
-            } catch (Exception ignore) { }
-            throw e;
-        }
-    }
+			post = new HttpPost(url);
+			safeSetHeader(post, SUMO_SOURCE_NAME_HEADER, sourceName);
+			safeSetHeader(post, SUMO_SOURCE_CATEGORY_HEADER, sourceCategory);
+			safeSetHeader(post, SUMO_SOURCE_HOST_HEADER, sourceHost);
+			safeSetHeader(post, SUMO_CLIENT_HEADER, clientHeaderValue);
+			post.setEntity(new StringEntity(body, Consts.UTF_8));
+			HttpResponse response = httpClient.execute(post);
+			int statusCode = response.getStatusLine().getStatusCode();
+			if (statusCode != 200) {
+				logger.warn("Received non-200 response code from Sumo Service: " + statusCode);
+				// Not success. Only retry if status matches retryableHttpCodeRegex
+				if (retryableHttpCodeRegexPattern.matcher(String.valueOf(statusCode)).find()) {
+					//need to consume the body if you want to re-use the connection.
+					EntityUtils.consume(response.getEntity());
+					throw new IOException("Encountered retryable status code: " + statusCode);
+				}
+			} else {
+				logger.debug("Successfully sent log request to Sumo Logic");
+			}
+			//need to consume the body if you want to re-use the connection.
+			EntityUtils.consume(response.getEntity());
+		} catch (ClientProtocolException e) {
+			logger.warn("Dropping message due to invalid URL: " + url);
+			try {
+				post.abort();
+			} catch (Exception ignore) { }
+			// Don't throw exception any further
+		} catch (IOException e) {
+			logger.warn("Could not send log to Sumo Logic. Reason: " + e.getMessage());
+			logger.debug(e);
+			try {
+				post.abort();
+			} catch (Exception ignore) { }
+			throw e;
+		}
+	}
 
-    private void safeSetHeader(HttpPost post, String name, String value) {
-        if (value != null && !value.trim().isEmpty()) {
-            post.setHeader(name, value);
-        }
-    }
+	private void safeSetHeader(HttpPost post, String name, String value) {
+		if (value != null && !value.trim().isEmpty()) {
+			post.setHeader(name, value);
+		}
+	}
 }


### PR DESCRIPTION
The use of static `String.format` method in the logger output was leftover from previous version when the the parameter was passed according the method signature:
`String java.lang.String.format(String format, Object... args)`
>Returns a formatted string using the specified format string and arguments.

As the logging string has changed to simple concatenated string, there is no need to use it.