### PR TITLE
Upgrading log4j-core to 2.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The library can be added to your project using Maven Central by adding the follo
 <dependency>
     <groupId>com.sumologic.plugins.http</groupId>
     <artifactId>sumologic-http-core</artifactId>
-    <version>1.6</version>
+    <version>1.7</version>
 </dependency>
 ```
 
@@ -66,9 +66,9 @@ To compile the plugin:
         <dependency>
             <groupId>com.sumologic.plugins.http</groupId>
             <artifactId>sumologic-http-core</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>1.7/version>
             <scope>system</scope>
-            <systemPath>/path/to/file/sumologic-http-core-1.0-SNAPSHOT.jar</systemPath>
+            <systemPath>/path/to/file/sumologic-http-core-1.7.jar</systemPath>
         </dependency>
     </dependencies>
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.sumologic.plugins.http</groupId>
     <artifactId>sumologic-http-core</artifactId>
-    <version>1.6</version>
+    <version>1.7</version>
     <packaging>jar</packaging>
     <name>Sumo Logic HTTP Core</name>
     <description>Core logic for queueing, aggregating, and sending to a Sumo Logic HTTP endpoint</description>
@@ -128,7 +128,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.15.0</version>
+            <version>2.16.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
Bump log4jcore version to 2.16.0 - [Disabled JNDI by default]
Update Version to 1.7
Update build note in readme.