### PR TITLE
Replacing log4j dependency with slf4j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,8 +64,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -126,9 +126,9 @@
             <version>4.5.13</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-            <version>2.17.0</version>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.32</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/src/main/java/com/sumologic/http/aggregation/BufferFlushingTask.java
+++ b/src/main/java/com/sumologic/http/aggregation/BufferFlushingTask.java
@@ -27,8 +27,8 @@
 package com.sumologic.http.aggregation;
 
 import com.sumologic.http.queue.BufferWithEviction;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -37,7 +37,7 @@ import java.util.List;
  * Task to perform a single flushing check
  */
 public abstract class BufferFlushingTask<In, Out> implements Runnable {
-    private static final Logger logger = LogManager.getRootLogger();
+    private static final Logger logger = LoggerFactory.getLogger(BufferFlushingTask.class);
     private long timeOfLastFlush = System.currentTimeMillis();
     private BufferWithEviction<In> messageQueue;
 

--- a/src/main/java/com/sumologic/http/queue/BufferWithFifoEviction.java
+++ b/src/main/java/com/sumologic/http/queue/BufferWithFifoEviction.java
@@ -26,8 +26,9 @@
 
 package com.sumologic.http.queue;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 
@@ -38,7 +39,7 @@ import static com.sumologic.http.queue.CostBoundedConcurrentQueue.CostAssigner;
  * the queue in batches.
  */
 public class BufferWithFifoEviction<T> extends BufferWithEviction<T> {
-    private static final Logger logger = LogManager.getRootLogger();
+    private static final Logger logger = LoggerFactory.getLogger(BufferWithFifoEviction.class);
     private CostBoundedConcurrentQueue<T> queue;
     private CostAssigner<T> costAssigner;
 

--- a/src/main/java/com/sumologic/http/sender/HttpProxySettingsCreator.java
+++ b/src/main/java/com/sumologic/http/sender/HttpProxySettingsCreator.java
@@ -26,6 +26,8 @@
 
 package com.sumologic.http.sender;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.http.HttpHost;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.NTCredentials;
@@ -33,11 +35,9 @@ import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.CredentialsProvider;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 public class HttpProxySettingsCreator {
-    private static final Logger logger = LogManager.getRootLogger();
+    private static final Logger logger = LoggerFactory.getLogger(HttpProxySettingsCreator.class);
     private ProxySettings proxySettings;
 
     public HttpProxySettingsCreator(ProxySettings proxySettings) {

--- a/src/main/java/com/sumologic/http/sender/SumoBufferFlushingTask.java
+++ b/src/main/java/com/sumologic/http/sender/SumoBufferFlushingTask.java
@@ -28,13 +28,13 @@ package com.sumologic.http.sender;
 
 import com.sumologic.http.aggregation.BufferFlushingTask;
 import com.sumologic.http.queue.BufferWithEviction;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
 public class SumoBufferFlushingTask extends BufferFlushingTask<String, String> {
-    private static final Logger logger = LogManager.getRootLogger();
+    private static final Logger logger = LoggerFactory.getLogger(SumoBufferFlushingTask.class);
     private SumoHttpSender sender;
     private long maxFlushIntervalMs;
     private int messagesPerRequest;

--- a/src/main/java/com/sumologic/http/sender/SumoHttpSender.java
+++ b/src/main/java/com/sumologic/http/sender/SumoHttpSender.java
@@ -26,6 +26,8 @@
 
 package com.sumologic.http.sender;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.http.Consts;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.ClientProtocolException;
@@ -38,15 +40,13 @@ import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.apache.http.util.EntityUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
 import java.util.regex.Pattern;
 
 
 public class SumoHttpSender {
-    private static final Logger logger = LogManager.getRootLogger();
+    private static final Logger logger = LoggerFactory.getLogger(SumoHttpSender.class);
 
     private static final String SUMO_SOURCE_NAME_HEADER = "X-Sumo-Name";
     private static final String SUMO_SOURCE_CATEGORY_HEADER = "X-Sumo-Category";
@@ -194,8 +194,7 @@ public class SumoHttpSender {
             } catch (Exception ignore) { }
             // Don't throw exception any further
         } catch (IOException e) {
-            logger.warn("Could not send log to Sumo Logic. Reason: " + e.getMessage());
-            logger.debug(e);
+            logger.warn("Could not send log to Sumo Logic", e);
             try {
                 post.abort();
             } catch (Exception ignore) { }

--- a/src/test/java/com/sumologic/http/sender/AggregatingHttpHandler.java
+++ b/src/test/java/com/sumologic/http/sender/AggregatingHttpHandler.java
@@ -28,8 +28,8 @@ package com.sumologic.http.sender;
 
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -41,7 +41,7 @@ import java.util.Queue;
 import java.util.concurrent.ArrayBlockingQueue;
 
 public class AggregatingHttpHandler implements HttpHandler {
-    private static final Logger logger = LogManager.getRootLogger();
+    private static final Logger logger = LoggerFactory.getLogger(AggregatingHttpHandler.class);
     private static String REQUEST_ENCODING = "UTF-8";
     private List<MaterializedHttpRequest> exchanges = new ArrayList<MaterializedHttpRequest>();
     private Queue<Integer> forceReturnCodes = new ArrayBlockingQueue<Integer>(100);


### PR DESCRIPTION
Two major changes:
- dropping the dependency on `log4j`. There's no meta usage here, it was just for logging actions from this library. `slf4j` gives more flexibility for downstream users
- upgrading to Java 8