### PR TITLE
BufferFlushingTask now honors messagesPerRequest when flushing

### DIFF
--- a/src/main/java/com/sumologic/http/aggregation/SumoBufferFlusher.java
+++ b/src/main/java/com/sumologic/http/aggregation/SumoBufferFlusher.java
@@ -42,7 +42,7 @@ public class SumoBufferFlusher {
 
     public SumoBufferFlusher(
             long flushingAccuracyMs,
-            long messagesPerRequest,
+            int messagesPerRequest,
             long maxFlushIntervalMs,
             SumoHttpSender sender,
             BufferWithEviction<String> buffer,
@@ -90,8 +90,8 @@ public class SumoBufferFlusher {
 
         if (flushingTask != null && flushBeforeStop) {
             // To satisfy needsFlushing in com.sumologic.http.aggregation.BufferFlushingTask for last flush before dying
-            flushingTask.setMessagesPerRequest(1L);
-            flushingTask.run();
+            flushingTask.setMessagesPerRequest(1);
+            flushingTask.flushAndSend();
         }
     }
 

--- a/src/main/java/com/sumologic/http/queue/BufferWithEviction.java
+++ b/src/main/java/com/sumologic/http/queue/BufferWithEviction.java
@@ -52,7 +52,7 @@ public abstract class BufferWithEviction<Q> {
     protected abstract Q evict();
     protected abstract boolean evict(long cost);
     public abstract int size();
-    public abstract int drainTo(Collection<Q> collection);
+    public abstract int drainTo(Collection<Q> collection, int atMost);
     public abstract boolean add(Q element);
 
 }

--- a/src/main/java/com/sumologic/http/queue/BufferWithFifoEviction.java
+++ b/src/main/java/com/sumologic/http/queue/BufferWithFifoEviction.java
@@ -92,8 +92,8 @@ public class BufferWithFifoEviction<T> extends BufferWithEviction<T> {
     }
 
     @Override
-    public int drainTo(Collection<T> collection) {
-        return queue.drainTo(collection);
+    public int drainTo(Collection<T> collection, int atMost) {
+        return queue.drainTo(collection, atMost);
     }
 
     @Override

--- a/src/main/java/com/sumologic/http/queue/CostBoundedConcurrentQueue.java
+++ b/src/main/java/com/sumologic/http/queue/CostBoundedConcurrentQueue.java
@@ -78,11 +78,11 @@ public class CostBoundedConcurrentQueue<T> {
      * @param collection Destination collection
      * @return the number of elements transferred
      */
-    public int drainTo(Collection<T> collection) {
+    public int drainTo(Collection<T> collection, int atMost) {
 
         assert collection.isEmpty();
 
-        int elementsDrained = queue.drainTo(collection);
+        int elementsDrained = queue.drainTo(collection, atMost);
         for (T e: collection) {
             cost.addAndGet(- costAssigner.cost(e));
         }

--- a/src/main/java/com/sumologic/http/sender/SumoBufferFlushingTask.java
+++ b/src/main/java/com/sumologic/http/sender/SumoBufferFlushingTask.java
@@ -37,7 +37,7 @@ public class SumoBufferFlushingTask extends BufferFlushingTask<String, String> {
     private static final Logger logger = LogManager.getRootLogger();
     private SumoHttpSender sender;
     private long maxFlushIntervalMs;
-    private long messagesPerRequest;
+    private int messagesPerRequest;
 
     public SumoBufferFlushingTask(BufferWithEviction<String> queue) {
         super(queue);
@@ -47,7 +47,7 @@ public class SumoBufferFlushingTask extends BufferFlushingTask<String, String> {
         this.sender = sender;
     }
 
-    public void setMessagesPerRequest(long messagesPerRequest) {
+    public void setMessagesPerRequest(int messagesPerRequest) {
         this.messagesPerRequest = messagesPerRequest;
     }
 
@@ -61,7 +61,7 @@ public class SumoBufferFlushingTask extends BufferFlushingTask<String, String> {
     }
 
     @Override
-    protected long getMessagesPerRequest() {
+    protected int getMessagesPerRequest() {
         return messagesPerRequest;
     }
 

--- a/src/test/java/com/sumologic/http/aggregation/BufferFlushingTaskTest.java
+++ b/src/test/java/com/sumologic/http/aggregation/BufferFlushingTaskTest.java
@@ -113,8 +113,24 @@ public class BufferFlushingTaskTest {
         assertTrue(tasks.isEmpty());
     }
 
+    @Test
+    public void testFlushDoesNotSendTooManyMessagesAtOnce() throws Exception {
+        // given
+        BufferFlushingTask<String, List<String>> task =
+                createTask(Integer.MAX_VALUE, 2);
+
+        // when
+        queue.add("msg1");
+        queue.add("msg2");
+        queue.add("msg3");
+        task.flushAndSend();
+
+        // test
+        assertEquals(2, tasks.get(0).size());
+    }
+
     private BufferFlushingTask<String, List<String>> createTask(
-            final long maxFlushIntervalMs, final long messagesPerRequest) {
+            final long maxFlushIntervalMs, final int messagesPerRequest) {
 
         return new BufferFlushingTask<String, List<String>>(queue) {
 
@@ -124,7 +140,7 @@ public class BufferFlushingTaskTest {
             }
 
             @Override
-            protected long getMessagesPerRequest() {
+            protected int getMessagesPerRequest() {
                 return messagesPerRequest;
             }
 

--- a/src/test/java/com/sumologic/http/queue/BufferWithFifoEvictionTest.java
+++ b/src/test/java/com/sumologic/http/queue/BufferWithFifoEvictionTest.java
@@ -84,7 +84,7 @@ public class BufferWithFifoEvictionTest {
         }
 
         List<Integer> result = new ArrayList<Integer>(10);
-        queue.drainTo(result);
+        queue.drainTo(result, Integer.MAX_VALUE);
 
         assertEquals(10, result.size());
         for (int i = 0; i < queue.size(); i++) {
@@ -102,7 +102,7 @@ public class BufferWithFifoEvictionTest {
         }
 
         List<Integer> result = new ArrayList<Integer>(3);
-        queue.drainTo(result);
+        queue.drainTo(result, Integer.MAX_VALUE);
 
         assertEquals(3, result.size());
         assertEquals(Arrays.asList(3, 4, 5), result);
@@ -119,7 +119,7 @@ public class BufferWithFifoEvictionTest {
         assertFalse(queue.add(1000));
 
         List<Integer> result = new ArrayList<Integer>(3);
-        queue.drainTo(result);
+        queue.drainTo(result, Integer.MAX_VALUE);
 
         assertEquals(Arrays.asList(1, 2, 3, 4, 5), result);
 
@@ -136,7 +136,7 @@ public class BufferWithFifoEvictionTest {
         assertTrue(queue.add(6));
 
         List<Integer> result = new ArrayList<Integer>(3);
-        queue.drainTo(result);
+        queue.drainTo(result, Integer.MAX_VALUE);
 
         assertEquals(3, result.size());
         assertEquals(Arrays.asList(4, 5, 6), result);

--- a/src/test/java/com/sumologic/http/queue/CostBoundedConcurrentQueueTest.java
+++ b/src/test/java/com/sumologic/http/queue/CostBoundedConcurrentQueueTest.java
@@ -110,7 +110,7 @@ public class CostBoundedConcurrentQueueTest {
         assertEquals(800, queue.cost());
 
         List<String> list = new ArrayList<String>(2);
-        queue.drainTo(list);
+        queue.drainTo(list, Integer.MAX_VALUE);
 
         assertEquals(0, queue.cost());
 


### PR DESCRIPTION
**Why**: Discovered with seemingly unrelated code change. `SumoHttpSenderTest.testRetryRegex()` has failed semi-deterministically (quite deterministic per machine, per JDK version, for some machines) with:
```
[ERROR] testRetryRegex(com.sumologic.http.sender.SumoHttpSenderTest)  Time elapsed: 2.063 s  <<< FAILURE!
java.lang.AssertionError: expected:<2> but was:<1>
	at com.sumologic.http.sender.SumoHttpSenderTest.testRetryRegex(SumoHttpSenderTest.java:278)
```
It turned out `flushAndSend()` didn't honor the `messagesPerRequest` setting. Thus sometimes (depending on how quickly the messages appeared in the input queue) it sent more than 1 message in one go.

Which was not what `SumoHttpSenderTest.testRetryRegex()` was expecting. Also I suppose legitimate/production code setting the `messagesPerRequest` wouldn't want to see more messages sent.

**What**: `BufferFlushingTask` on flush sends at most `messagesPerRequest` in one go.
